### PR TITLE
[HOTFIX] Muda comparação durante RemoverEstoque

### DIFF
--- a/src/main/java/com/biblioteca/Biblioteca.java
+++ b/src/main/java/com/biblioteca/Biblioteca.java
@@ -96,7 +96,7 @@ public class Biblioteca {
         
         LivroEstoque aremover = null;
         for (LivroEstoque e : estoque) {
-            if (e.livro.isbn.equals(e.livro.isbn)) {
+            if (e.livro.isbn.equals(livroEstoque.livro.isbn)) {
                 aremover = e;
             }
         }


### PR DESCRIPTION
O método RemoverEstoque estava comparando os livros contra eles mesmos dentro do for, causando um bug em que o LivroEstoque incorreto era deletado da lista. Ao mudar para o LivroEstoque que é recebido como parâmetro, este bug é solucionado.